### PR TITLE
Ensures the filename exists to avoid RCE

### DIFF
--- a/lib/dearchiver/processor.rb
+++ b/lib/dearchiver/processor.rb
@@ -29,6 +29,7 @@ module Dearchiver
     def initialize(options = {})
       @filename = options[:filename]
       raise ArgumentError, "Processor: :filename required!" if @filename.nil? or @filename.empty?
+      raise RuntimeError, "Processor: :filename does not exist!" unless File.exist?(@filename)
 
       if options[:archive_type].nil? or options[:archive_type].empty?
         @archive_type = File.extname(@filename) if valid_file_type?


### PR DESCRIPTION
I Would also shell escape filename and destination in all the gsub to be on the safe side just in case (You will need the shellwords lib for that, see https://github.com/erwanlr/Fingerprinter/blob/convert-dbs/lib/fingerprinter/archive.rb)

Can see the RCE with a filename like 'test&ls;.zip'

```
d = Dearchiver.new(filename: 'test&ls;.zip')
d.extract_to('/tmp')

p d.execution_output # Will reveals the result of the 'ls' command
```