### PR TITLE
Force the encoding of the command result to UTF-8

### DIFF
--- a/lib/dearchiver/processor.rb
+++ b/lib/dearchiver/processor.rb
@@ -73,9 +73,8 @@ module Dearchiver
 
     def execute_command(command)
       @executed_command = command
-      result = %x[#{command}]
-      @execution_output = result
-      result
+      
+      @execution_output = %x[#{command}].encode('UTF-8', invalid: :replace, undef: :replace)
     end
 
     def archive_options


### PR DESCRIPTION
If a file whiten an archive contains a char which is not in the UTF-8 encoding, ruby will raise an error when extracting it while computing the list of files:

```
/[redacted]/.rvm/gems/ruby-2.3.3/gems/dearchiver-0.0.1/lib/dearchiver/processor.rb:65:in `scan': invalid byte sequence in UTF-8 (ArgumentError)
```

Can be reproduced by downloading and using the gem to extract the below archive:

https://downloads.wordpress.org/plugin/woo-payment-for-banknet-in-viet-nam.1.0.zip