### PR TITLE
Fix .zip extraction pattern for MacOsx

### DIFF
--- a/lib/dearchiver/processor.rb
+++ b/lib/dearchiver/processor.rb
@@ -84,7 +84,7 @@ module Dearchiver
               :crc_check => "unzip -t <filename>",
               :crc_ok => "No errors detected in compressed data",
               :decompress => "unzip -o <filename> -d <extractdir>",
-              :file_list_regex => /extracting: (.+)/,
+              :file_list_regex => /(?:extracting|inflating): (.+)/,
               :compress => "zip <extractdir>/<filename> <extractdir>/<filename>"
           },
           ".rar" => {


### PR DESCRIPTION
On MacOsx, 'inflating: ' is output when extracting files from a .zip